### PR TITLE
Replace a tab to spaces and fix implicit cast that is not allowed in Windows

### DIFF
--- a/src/simulators/clifford_plus_phase/ag_state.hpp
+++ b/src/simulators/clifford_plus_phase/ag_state.hpp
@@ -108,7 +108,7 @@ public:
    */
   std::pair<bool, size_t> apply_constraints(size_t w, size_t t);
   size_t apply_T_constraints();
-  /*	
+  /*
    * Go through our stabilizer table and delete every qubit for which every stabilizer is the identity on that qubit
    * In other words delete every column from the X and Z matrices if both are 0 for every element in that column
    * intended only for use when we have restricted our table to only have magic qubits
@@ -311,7 +311,7 @@ void AGState::delete_identity_magic_qubits(){
     size_t non_identity_paulis = 0;
     for(size_t s = 0; (s < this->num_stabilizers) && (non_identity_paulis == 0); s++){
       if(this->table[s].X[q] || this->table[s].Z[q]){
-	non_identity_paulis += 1;
+        non_identity_paulis += 1;
       }
     }
     if(non_identity_paulis == 0){
@@ -320,11 +320,11 @@ void AGState::delete_identity_magic_qubits(){
       qubits_deleted += 1;
     }else{
       if(qubits_deleted > 0){
-	for(size_t s = 0; s < this->num_stabilizers; s++){
-	  this->table[s].X.setValue(this->table[s].X[q], q-qubits_deleted);
-	  this->table[s].Z.setValue(this->table[s].Z[q], q-qubits_deleted);
-	}
-	magic_phases[q - qubits_deleted] = magic_phases[q];
+        for(size_t s = 0; s < this->num_stabilizers; s++){
+          this->table[s].X.setValue(this->table[s].X[q], q-qubits_deleted);
+          this->table[s].Z.setValue(this->table[s].Z[q], q-qubits_deleted);
+        }
+        magic_phases[q - qubits_deleted] = magic_phases[q];
       }
     }
   }
@@ -433,13 +433,13 @@ std::vector<Operations::Op> AGState::simplifying_unitary(){
     }else{
       size_t pivot = poss_pivot.second; //now known to exist
       if(pivot != h){
-	//swap rows h and pivot of the table
-	this->swap_rows(h,pivot);
+        //swap rows h and pivot of the table
+        this->swap_rows(h,pivot);
       }
       for(size_t j = 0; j < this->num_stabilizers; j++){
-	if((j != h) && this->table[j].X[k]){
-	  this->rowsum(j,h);
-	}
+        if((j != h) && this->table[j].X[k]){
+          this->rowsum(j,h);
+        }
       }
       h += 1;
       k += 1;
@@ -468,8 +468,8 @@ std::vector<Operations::Op> AGState::simplifying_unitary(){
   for(size_t r = 0; r < this->num_stabilizers; r++){
     for(size_t col = this->num_stabilizers; col < this->num_qubits; col++){
       if(this->table[r].X[col]){
-	this->applyCX(r, col);
-	circuit.push_back(make_CX(r,col));
+        this->applyCX(r, col);
+        circuit.push_back(make_CX(r,col));
       }
     }
   }
@@ -486,8 +486,8 @@ std::vector<Operations::Op> AGState::simplifying_unitary(){
   for(size_t col = this->num_stabilizers; col < this->num_qubits; col++){
     for(size_t r = 0; r < this->num_stabilizers; r++){
       if(this->table[r].Z[col]){
-	this->applyCZ(r, col);
-	circuit.push_back(make_CZ(r, col));
+        this->applyCZ(r, col);
+        circuit.push_back(make_CZ(r, col));
       }
     }
   }
@@ -496,8 +496,8 @@ std::vector<Operations::Op> AGState::simplifying_unitary(){
   for(size_t col = 0; col < this->num_stabilizers; col++){
     for(size_t r = 0; r < col; r++){
       if(this->table[r].Z[col]){
-	this->applyCZ(r, col);
-	circuit.push_back(make_CZ(r, col));
+        this->applyCZ(r, col);
+        circuit.push_back(make_CZ(r, col));
       }
     }
   }
@@ -576,37 +576,37 @@ bool AGState::independence_test(int q){
     
     if(x.first){
       if(x.second != a){
-	this->swap_rows(a, x.second);
+        this->swap_rows(a, x.second);
       }
       if(z.first && (z.second == a)){
-	z = x;
+        z = x;
       }
       for(size_t j = 0; j < this->num_stabilizers; j++){
-	if((j != a) && this->table[j].X[b]){
-	  this->rowsum(j,a);
-	}
+        if((j != a) && this->table[j].X[b]){
+          this->rowsum(j,a);
+        }
       }
       a += 1;
     }
     if(y.first){
       if(y.second != a){
-	this->swap_rows(a,y.second);
+        this->swap_rows(a,y.second);
       }
       for(size_t j = 0; j < this->num_stabilizers; j++){
-	if((j != a) && this->table[j].X[b] && this->table[j].Z[b]){
-	  this->rowsum(j,a);
-	}
+        if((j != a) && this->table[j].X[b] && this->table[j].Z[b]){
+          this->rowsum(j,a);
+        }
       }
       a += 1;
     }
     if(z.first){
       if(z.second != a){
-	this->swap_rows(a,z.second);
+        this->swap_rows(a,z.second);
       }
       for(size_t j = 0; j < this->num_stabilizers; j++){
-	if((j != a) && this->table[j].Z[b]){
-	  this->rowsum(j,a);
-	}
+        if((j != a) && this->table[j].Z[b]){
+          this->rowsum(j,a);
+        }
       }
       a += 1;
     }
@@ -643,16 +643,16 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
     for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabilisers
       
       if(this->table[s].X[q] && this->table[s].Z[q]){
-	y_stab.first = true;
-	y_stab.second = s;
+        y_stab.first = true;
+        y_stab.second = s;
       }
       if(this->table[s].X[q] && !this->table[s].Z[q]){
-	x_stab.first = true;
-	x_stab.second = s;
+        x_stab.first = true;
+        x_stab.second = s;
       }
       if(!this->table[s].X[q] && this->table[s].Z[q]){
-	z_stab.first = true;
-	z_stab.second = s;
+        z_stab.first = true;
+        z_stab.second = s;
       }
     }
     //there are several cases here
@@ -662,15 +662,15 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
     //put things in standard form (first stab is x then z)    
     if((y_stab.first + x_stab.first + z_stab.first) >= 2){ //we have at least two of the set
       if(!x_stab.first){//we don't have a generator for x alone, but we can make one
-	this->rowsum(y_stab.second, z_stab.second);
-	//now we have a z and an x but not a y
-	x_stab = y_stab;
-	y_stab = std::pair<bool, size_t>(false,0);
+        this->rowsum(y_stab.second, z_stab.second);
+        //now we have a z and an x but not a y
+        x_stab = y_stab;
+        y_stab = std::pair<bool, size_t>(false,0);
       }else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
-	this->rowsum(y_stab.second, x_stab.second);
-	//now we have a z and an x but not a y
-	z_stab = y_stab;
-	y_stab = std::pair<bool, size_t>(false,0);
+        this->rowsum(y_stab.second, x_stab.second);
+        //now we have a z and an x but not a y
+        z_stab = y_stab;
+        y_stab = std::pair<bool, size_t>(false,0);
       }
     }
     
@@ -683,17 +683,17 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
     //zero everything else on this qubit
     for(size_t s = 0; s < this->num_stabilizers; s++){
       if((!y_stab.first || s != y_stab.second) && (!x_stab.first || s != x_stab.second) && (!z_stab.first || s != z_stab.second)){
-	if(this->table[s].X[q] && this->table[s].Z[q] && y_stab.first){
-	  this->rowsum(s, y_stab.second);
-	}
-	
-	if(this->table[s].X[q]){
-	  this->rowsum(s, x_stab.second);
-	}
-	
-	if(this->table[s].Z[q]){
-	  this->rowsum(s, z_stab.second);
-	}
+        if(this->table[s].X[q] && this->table[s].Z[q] && y_stab.first){
+          this->rowsum(s, y_stab.second);
+        }
+
+        if(this->table[s].X[q]){
+          this->rowsum(s, x_stab.second);
+        }
+
+        if(this->table[s].Z[q]){
+          this->rowsum(s, z_stab.second);
+        }
       }
     }
 
@@ -714,17 +714,17 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
       bool independent = this->independence_test(q);
       
       if(!independent){
-	if(this->phases[this->num_stabilizers-1] == 0){
-	  // +Z_q
-	  v += 1;
-	  this->delete_last_row();
-	}else{
-	  //our chosen measurement outcome is impossible	  
-	  return std::pair<bool, size_t>(false,0);
-	}
+        if(this->phases[this->num_stabilizers-1] == 0){
+          // +Z_q
+          v += 1;
+          this->delete_last_row();
+        }else{
+          //our chosen measurement outcome is impossible
+          return std::pair<bool, size_t>(false,0);
+        }
       }else{
-	//if we get here there has been an error
-	//TODO decide if we're going to throw an exception or print an error message here
+        //if we get here there has been an error
+        //TODO decide if we're going to throw an exception or print an error message here
       }
     }
   }
@@ -737,16 +737,16 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
 
     for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabilisers
       if(this->table[s].X[q] && this->table[s].Z[q]){
-	y_stab.first = true;
-	y_stab.second = s;
+        y_stab.first = true;
+        y_stab.second = s;
       }
       if(this->table[s].X[q] && !this->table[s].Z[q]){
-	x_stab.first = true;
-	x_stab.second = s;
+        x_stab.first = true;
+        x_stab.second = s;
       }
       if(!this->table[s].X[q] && this->table[s].Z[q]){
-	z_stab.first = true;
-	z_stab.second = s;
+        z_stab.first = true;
+        z_stab.second = s;
       }
     }
 
@@ -757,15 +757,15 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
     //put things in standard form (first stab is x then z)    
     if((y_stab.first + x_stab.first + z_stab.first) >= 2){ //we have at least two of the set
       if(!x_stab.first){//we don't have a generator for x alone, but we can make one
-	this->rowsum(y_stab.second, z_stab.second);
-	//now we have a z and an x but not a y
-	x_stab = y_stab;
-	y_stab = std::pair<bool, size_t>(false,0);
+        this->rowsum(y_stab.second, z_stab.second);
+        //now we have a z and an x but not a y
+        x_stab = y_stab;
+        y_stab = std::pair<bool, size_t>(false,0);
       }else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
-	this->rowsum(y_stab.second, x_stab.second);
-	//now we have a z and an x but not a y
-	z_stab = y_stab;
-	y_stab = std::pair<bool, size_t>(false,0);
+        this->rowsum(y_stab.second, x_stab.second);
+        //now we have a z and an x but not a y
+        z_stab = y_stab;
+        y_stab = std::pair<bool, size_t>(false,0);
       }
     }
     
@@ -778,17 +778,17 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
     //zero everything else on this qubit
     for(size_t s = 0; s < this->num_stabilizers; s++){
       if((!y_stab.first || s != y_stab.second) && (!x_stab.first || s != x_stab.second) && (!z_stab.first || s != z_stab.second)){
-	if(this->table[s].X[q] && this->table[s].Z[q] && y_stab.first){
-	  this->rowsum(s, y_stab.second);
-	}
-	
-	if(this->table[s].X[q]){
-	  this->rowsum(s, x_stab.second);
-	}
-	
-	if(this->table[s].Z[q]){
-	  this->rowsum(s, z_stab.second);
-	}
+        if(this->table[s].X[q] && this->table[s].Z[q] && y_stab.first){
+          this->rowsum(s, y_stab.second);
+        }
+
+        if(this->table[s].X[q]){
+          this->rowsum(s, x_stab.second);
+        }
+
+        if(this->table[s].Z[q]){
+          this->rowsum(s, z_stab.second);
+        }
       }
     }
     
@@ -800,15 +800,15 @@ std::pair<bool, size_t> AGState::apply_constraints(size_t w, size_t t){
       num_to_delete += 1;
     }else{
       if(x_stab.first){
-	this->swap_rows(x_stab.second, this->num_stabilizers-1);
-	if(z_stab.first && (this->num_stabilizers - 1 == z_stab.second)){
-	  z_stab = x_stab;
-	}
-	num_to_delete += 1;
+        this->swap_rows(x_stab.second, this->num_stabilizers-1);
+        if(z_stab.first && (this->num_stabilizers - 1 == z_stab.second)){
+          z_stab = x_stab;
+        }
+        num_to_delete += 1;
       }
       if(z_stab.first){
-	this->swap_rows(z_stab.second, this->num_stabilizers-1-num_to_delete);
-	num_to_delete += 1;
+        this->swap_rows(z_stab.second, this->num_stabilizers-1-num_to_delete);
+        num_to_delete += 1;
       }
     }
 
@@ -839,19 +839,19 @@ size_t AGState::apply_T_constraints(){
       std::pair<bool, size_t> x_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with x=1, z=0
       std::pair<bool, size_t> z_stab = std::pair<bool, size_t>(false,0); //store the index of the first stab we come to with z=1, x=0
       
-      for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabi	lisers
-	if(this->table[s].X[q] && this->table[s].Z[q]){
-	  y_stab.first = true;
-	  y_stab.second = s;
+      for(size_t s=0; s < this->num_stabilizers && (((!y_stab.first) + (!x_stab.first) + (!z_stab.first)) > 1); s++){//iterate over all stabilisers and find interesting stabi        lisers
+        if(this->table[s].X[q] && this->table[s].Z[q]){
+          y_stab.first = true;
+          y_stab.second = s;
       }
-	if(this->table[s].X[q] && !this->table[s].Z[q]){
-	  x_stab.first = true;
-	  x_stab.second = s;
-	}
-	if(!this->table[s].X[q] && this->table[s].Z[q]){
-	  z_stab.first = true;
-	  z_stab.second = s;
-	}
+        if(this->table[s].X[q] && !this->table[s].Z[q]){
+          x_stab.first = true;
+          x_stab.second = s;
+        }
+        if(!this->table[s].X[q] && this->table[s].Z[q]){
+          z_stab.first = true;
+          z_stab.second = s;
+        }
       }
       
       //there are several cases here
@@ -860,38 +860,38 @@ size_t AGState::apply_T_constraints(){
       //case 1) we generate the whole group
       //put things in standard form (first stab is x then z)    
       if((y_stab.first + x_stab.first + z_stab.first) >= 2){ //we have at least two of the set
-	if(!x_stab.first){//we don't have a generator for x alone, but we can make one
-	  this->rowsum(y_stab.second, z_stab.second);
-	  //now we have a z and an x but not a y
-	  x_stab = y_stab;
-	  y_stab = std::pair<bool, size_t>(false,0);
-	}else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
-	  this->rowsum(y_stab.second, x_stab.second);
-	  //now we have a z and an x but not a y
-	  z_stab = y_stab;
-	  y_stab = std::pair<bool, size_t>(false,0);
-	}
+        if(!x_stab.first){//we don't have a generator for x alone, but we can make one
+          this->rowsum(y_stab.second, z_stab.second);
+          //now we have a z and an x but not a y
+          x_stab = y_stab;
+          y_stab = std::pair<bool, size_t>(false,0);
+        }else if(!z_stab.first){//we don't have a generator for z alone, but we can make one
+          this->rowsum(y_stab.second, x_stab.second);
+          //now we have a z and an x but not a y
+          z_stab = y_stab;
+          y_stab = std::pair<bool, size_t>(false,0);
+        }
       }
       
       if(y_stab.first && x_stab.first && z_stab.first){ //we have all 3
-	//ignore the y one if we have all 3
-	y_stab = std::pair<bool, size_t>(false,0);
+        //ignore the y one if we have all 3
+        y_stab = std::pair<bool, size_t>(false,0);
       }
       
       if(z_stab.first && !x_stab.first){
-	//kill all other z stuff on this qubit	
-	for(size_t s = 0; s < this->num_stabilizers; s++){
-	  if((s != z_stab.second) && this->table[s].Z[q]){
-	    this->rowsum(s, z_stab.second);
-	  }
-	}
-	//now delete the z guy
+        //kill all other z stuff on this qubit
+        for(size_t s = 0; s < this->num_stabilizers; s++){
+          if((s != z_stab.second) && this->table[s].Z[q]){
+            this->rowsum(s, z_stab.second);
+          }
+        }
+        //now delete the z guy
 
-	if(z_stab.second != this->num_stabilizers-1){
-	  this->swap_rows(z_stab.second, this->num_stabilizers-1);
-	}
-	this->delete_last_row();
-	deleted_rows += 1;
+        if(z_stab.second != this->num_stabilizers-1){
+          this->swap_rows(z_stab.second, this->num_stabilizers-1);
+        }
+        this->delete_last_row();
+        deleted_rows += 1;
       }
     }
   }

--- a/src/simulators/clifford_plus_phase/compute.hpp
+++ b/src/simulators/clifford_plus_phase/compute.hpp
@@ -67,7 +67,7 @@ public:
 private:  
   const static stringmap_t<Gates> gateset_;
   size_t num_code_qubits; //out AG state has code+magic qubits
-  double compute_probability(std::vector<size_t> measured_qubits, std::vector<uint_t> outcomes);
+  double compute_probability(std::vector<uint_t> measured_qubits, std::vector<uint_t> outcomes);
 };
 
 
@@ -193,8 +193,8 @@ double compute_algorithm_all_phases_T(AGState &state){
     size_t bit_to_flip = 0;
     for(size_t j = 0; j < state.num_stabilizers; j++){
       if((mask_with_bit_to_flip >> j) & ONE){
-	bit_to_flip = j;
-	break;
+        bit_to_flip = j;
+        break;
       }
     }
 
@@ -211,22 +211,22 @@ double compute_algorithm_all_phases_T(AGState &state){
       //    ICount += 1;
       //}
       if(row.X[j] && !row.Z[j]){
-	XCount += 1;
+        XCount += 1;
       }
       if(!row.X[j] && row.Z[j]){
-	ZCount += 1;
-	break;
+        ZCount += 1;
+        break;
       }
       if(row.X[j] && row.Z[j]){
-	YCount += 1;
+        YCount += 1;
       }
     }
     
     if(ZCount == 0){
       if(((phase + YCount) % 2) == 0){
-	acc += powl(1./2., (XCount + YCount)/2.);;
+        acc += powl(1./2., (XCount + YCount)/2.);;
       }else{
-	acc -= powl(1./2., (XCount + YCount)/2.);;
+        acc -= powl(1./2., (XCount + YCount)/2.);;
       }
     }      
   }
@@ -251,8 +251,8 @@ double compute_algorithm_arbitrary_phases(AGState &state){
     size_t bit_to_flip = 0;
     for(size_t j = 0; j < state.num_stabilizers; j++){
       if((mask_with_bit_to_flip >> j) & ONE){
-	bit_to_flip = j;
-	break;
+        bit_to_flip = j;
+        break;
       }
     }
     
@@ -265,14 +265,14 @@ double compute_algorithm_arbitrary_phases(AGState &state){
       //    ICount += 1;
       //}
       if(row.X[j] && !row.Z[j]){
-	prod *= cos(state.magic_phases[j]);
+        prod *= cos(state.magic_phases[j]);
       }
       if(!row.X[j] && row.Z[j]){
-	prod = 0.;
-	break;
+        prod = 0.;
+        break;
       }
       if(row.X[j] && row.Z[j]){
-	prod *= -sin(state.magic_phases[j]);
+        prod *= -sin(state.magic_phases[j]);
       }
     }
     if(phase){
@@ -289,33 +289,33 @@ double compute_algorithm_arbitrary_phases(AGState &state){
 }
 
 
-double State::compute_probability(std::vector<size_t> measured_qubits, std::vector<uint_t> outcomes){
+double State::compute_probability(std::vector<uint_t> measured_qubits, std::vector<uint_t> outcomes){
 
   AGState copied_ag(this->qreg_); //copy constructor TODO check this
 
   //first reorder things so the first w qubits are measured
-  std::vector<size_t> measured_qubits_sorted(measured_qubits);
+  std::vector<uint_t> measured_qubits_sorted(measured_qubits);
 
-  std::vector<size_t> qubit_indexes;
-  for(size_t i = 0; i < this->qreg_.num_qubits; i++){
+  std::vector<uint_t> qubit_indexes;
+  for(uint_t i = 0; i < this->qreg_.num_qubits; i++){
     qubit_indexes.push_back(i);
   }  
   std::sort(measured_qubits_sorted.begin(), measured_qubits_sorted.end());
   
-  for(size_t i = 0; i < measured_qubits.size(); i++){
-    size_t w = measured_qubits_sorted[i];    
-    size_t idx1 = 0;
-    size_t idx2 = 0;
-    for(size_t j = 0; j < qubit_indexes.size(); j++){
+  for(uint_t i = 0; i < measured_qubits.size(); i++){
+    uint_t w = measured_qubits_sorted[i];
+    uint_t idx1 = 0;
+    uint_t idx2 = 0;
+    for(uint_t j = 0; j < qubit_indexes.size(); j++){
       if(qubit_indexes[j] == w){
-	idx1 = j;
-	break;
+        idx1 = j;
+        break;
       }
     }
-    for(size_t j = 0; j < measured_qubits.size(); j++){
+    for(uint_t j = 0; j < measured_qubits.size(); j++){
       if(measured_qubits[j] == w){
-	idx2 = j;
-	break;
+        idx2 = j;
+        break;
       }
     }
     
@@ -328,29 +328,29 @@ double State::compute_probability(std::vector<size_t> measured_qubits, std::vect
   //from this point on we will assume we're looking for the measurement outcome 0 on all measured qubits
   //so apply X gates to measured qubits where we're looking for outcome 1 to correct this
   //now all the measured qubits are at the start and the magic qubits are at the end
-  for(size_t i = 0; i < outcomes.size(); i++){
+  for(uint_t i = 0; i < outcomes.size(); i++){
     if(outcomes[i] == 1){
       copied_ag.applyX(i);
     }
   }
 
-  size_t w = measured_qubits.size();
-  size_t t = copied_ag.magic_phases.size();
+  uint_t w = measured_qubits.size();
+  uint_t t = copied_ag.magic_phases.size();
 
   //now all the measured qubits are at the start and the magic qubits are at the end
 
-  std::pair<bool, size_t> v_pair = copied_ag.apply_constraints(w, t);
+  std::pair<bool, uint_t> v_pair = copied_ag.apply_constraints(w, t);
   if(!v_pair.first){
     return 0.;
   }
-  size_t v = v_pair.second;
+  uint_t v = v_pair.second;
 
   //at this point we can delete all the non-magic qubits
-  for(size_t q = 0; q < t; q++){
+  for(uint_t q = 0; q < t; q++){
     copied_ag.applySwap(q, q+(copied_ag.num_qubits - t));
   }
   
-  for(size_t s = 0; s < copied_ag.num_stabilizers; s++){
+  for(uint_t s = 0; s < copied_ag.num_stabilizers; s++){
     copied_ag.table[s].X.resize(t);
     copied_ag.table[s].Z.resize(t);
   }
@@ -362,7 +362,7 @@ double State::compute_probability(std::vector<size_t> measured_qubits, std::vect
   //we can make the compute algorithm much faster if all of our non-Clifford gates are in fact T gates (pi/4 rotations)
 
   bool all_phases_are_T = true;
-  for(size_t i = 0; i < copied_ag.num_qubits; i++){
+  for(uint_t i = 0; i < copied_ag.num_qubits; i++){
     if(fabs(copied_ag.magic_phases[i] - T_ANGLE) > AG_CHOP_THRESHOLD){
       all_phases_are_T  = false;
       break;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- Replace a tab to spaces.
- Fix implicit cast that is not allowed in Windows

### Details and comments

I guess a reason of [this error](https://github.com/Qiskit/qiskit-aer/runs/3125908579#step:6:1896) is that implicit cast from "std::vector<uint_t>" to "std::vector<size_t>" is not allowed in Windows.